### PR TITLE
Fixed joining of generated it tests

### DIFF
--- a/lib/test-generator.js
+++ b/lib/test-generator.js
@@ -156,7 +156,12 @@ const testMapper = {
 const generateItTests = (fixture) => {
   const result = []
   const spdtKeys = Object.keys(R.propOr({}, 'spdt', fixture))
-  spdtKeys.forEach((checkItem) => testMapper[checkItem] && result.push(testMapper[checkItem](fixture)))
+  spdtKeys.forEach((checkItem) => {
+    if (testMapper[checkItem]) {
+      const test = testMapper[checkItem](fixture)
+      result.push(Array.isArray(test) ? test.join('') : test)
+    }
+  })
   return result.join('')
 }
 
@@ -186,6 +191,7 @@ module.exports = {
   testGenerator,
   getFileName,
   generateContent,
+  generateItTests,
   testCheckArcs,
   testCheckBars,
   testCheckSvg,

--- a/tests/test-generator.test.js
+++ b/tests/test-generator.test.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import {
   generateContent,
+  generateItTests,
   getFileName,
   ROOT_SELECTOR,
   saveFile,
@@ -9,6 +10,7 @@ import {
   testCheckBars,
   testCheckSvg,
   testGenerator,
+  testCheckSelector,
 } from '../lib/test-generator'
 import { STORYBOOK_PORT } from '../lib/config'
 import fixtures from '../example-src/components/simple-component.fixture'
@@ -83,6 +85,19 @@ describe('Test Generator', () => {
       pathToTestIndex,
     })
     expect(true).toBeTruthy()
+  })
+  it('generateItTests: should correct compose tests', () => {
+    const fixture = {
+      props: {
+        title: 'Component Title',
+        children: 'Some children components',
+      },
+      spdt: {
+        checkSelector: ['div.simple-component', 'div.simple-component-item'],
+      },
+    }
+    const expected = testCheckSelector(fixture).join('')
+    expect(generateItTests(fixture)).toEqual(expected)
   })
 
   it('testCheckArcs: when declaration not set should return empty string', () => {


### PR DESCRIPTION
There is an issue on generating tests when a test declaration returns an array.
For example:
```
 checkSelector: ['div.simple-component', 'div.simple-component-item']
```
generates:
```
it('checkSelector: should find component matching selector [div.simple-component] 1 time(s)',
...
}),
it('checkSelector: should find component matching selector [div.simple-component-item] 1 time(s)',     
...
})
```
Comma between tests makes syntax error.